### PR TITLE
config sample fixes

### DIFF
--- a/src/config_sample.js
+++ b/src/config_sample.js
@@ -3,7 +3,7 @@
 exports.telegramAPIToken = ""; // Your telegram bot API key. Ask the @botfather for an api key
 exports.userId = ""; // your telegram id. This will make sure that the msgs are sent only to you
 exports.OTPsecret = ""; // run "npm run generate-password" in order to get this setting
-exports.localNodeURL = "http://127.0.0.1:8000"; // If you want to use for testing "https://node04.lisk.io/api/node/status" or use your node in testnet, don't forget the port 7000
+exports.localNodeURL = "http://127.0.0.1:8000"; // If you want to use for testing "https://node04.lisk.io" or use your node in testnet, don't forget the port 7000
 exports.diffBlockHeight = 3; // The difference of block heights between your node and the others before triggering an alarm
 exports.minBlockHeightNodeMatch = -3; // The difference of block heights between your node and the others before triggering an alarm
 exports.rebootWelcome = true; // The reboot telegram message
@@ -11,7 +11,7 @@ exports.nodeName = "My node"; // Used to identify which node is being referred t
 exports.minutesBetweenTexts = 15; // How many mins. before sending another SMS
 
 exports.textMagicData = {
-  enabled: false, // switch to true only if you have the following credentials fro textMagic.
+  enabled: false, // switch to true only if you have the following credentials for textMagic.
   username: "",
   APIkey: "",
   phoneNumber: "",
@@ -19,7 +19,7 @@ exports.textMagicData = {
 };
 
 exports.twilioData = {
-  enabled: false, // switch to true only if you have the following credentials fro Twilio.
+  enabled: false, // switch to true only if you have the following credentials for Twilio.
   username: "",
   password: "",
   fromPhoneNumber: "",

--- a/src/config_sample.js_testnet
+++ b/src/config_sample.js_testnet
@@ -1,9 +1,9 @@
 // Create a new file called "config.js" and replace all the fields with your configuration
 
 exports.telegramAPIToken = ""; // Your telegram bot API key. Ask the @botfather for an api key
-exports.chatId = ""; // your telegram id. This will make sure that the msgs are sent only to you
+exports.userId = ""; // your telegram id. This will make sure that the msgs are sent only to you
 exports.OTPsecret = ""; // run "npm run generate-password" in order to get this setting
-exports.localNodeURL = "http://127.0.0.1:7000/api/node/status/"; // If you want to use for testing "https://node04.lisk.io/api/loader/status/sync" or use your node in testnet, don't forget the port 7000
+exports.localNodeURL = "http://127.0.0.1:7000"; // If you want to use for testing "https://node04.lisk.io" or use your node in testnet, don't forget the port 7000
 exports.diffBlockHeight = 2; // The difference of block heights between your node and the others before triggering an alarm
 exports.minBlockHeightNodeMatch = -3; // The difference of block heights between your node and the others before triggering an alarm
 exports.rebootWelcome = true; // The reboot telegram message
@@ -11,7 +11,7 @@ exports.nodeName = "My node"; // Used to identify which node is being referred t
 exports.minutesBetweenTexts = 15; // How many mins. before sending another SMS
 
 exports.textMagicData = {
-  enabled: false, // switch to true only if you have the following credentials fro textMagic.
+  enabled: false, // switch to true only if you have the following credentials for textMagic.
   username: "",
   APIkey: "",
   phoneNumber: "",
@@ -19,7 +19,7 @@ exports.textMagicData = {
 };
 
 exports.twilioData = {
-  enabled: false, // switch to true only if you have the following credentials fro Twilio.
+  enabled: false, // switch to true only if you have the following credentials for Twilio.
   username: "",
   password: "",
   fromPhoneNumber: "",


### PR DESCRIPTION
-In testnet config sample, exports.chatId was not changed to exports.userId

-In testnet config sample, full API call path for node status was not truncated

-Both sample configs contained a small spelling mistake in two comments